### PR TITLE
Switch to JSON and Base64 when sending/receiving files from OS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -180,15 +180,17 @@ const getContainerList = function (securityToken, containerUrl) {
 const putObject = function (securityToken, containerUrl, containerName, objectName, objectMimetype, objectContents) {
   const url = `${containerUrl}/${containerName}/${objectName}`;
   const headers = {
-    'X-Auth-Token': securityToken,
-    // Note: this will override swiftRequest content-type header
-    'Content-Type': objectMimetype
+    'X-Auth-Token': securityToken
   };
   const data = objectContents;
+  
+  const encData = new Buffer(data).toString('base64');
+  const jsonSrc = {'mimeType' : objectMimetype, 'metadata' : {}, 'valuetransferencoding' : 'base64', 'value' : encData};
+  const json = JSON.stringify(jsonSrc);
 
   debug(`Uploading ${objectName} object to ${containerName} storage`);
 
-  return swiftRequest('put', url, headers, data);
+  return swiftRequest('put', url, headers, json);
 };
 
 const getObject = function (securityToken, containerUrl, containerName, objectName) {
@@ -213,6 +215,9 @@ const getObject = function (securityToken, containerUrl, containerName, objectNa
         return new Buffer(obj.data);
       // if incomming data is already a buffer
       } else {
+        if (typeof obj.value !== "undefined") {
+          obj.value = new Buffer(obj.value, 'base64');
+        }
         return obj;
       }
    });


### PR DESCRIPTION
If you upload a file to Object Storage through the FIWARE Lab website GUI and then download that same file using the REST interface, you will notice that the payload has the following format:

{'mimeType' : fileMimeType, 'metadata' : fileMetadata, 'valuetransferencoding' : 'base64', 'value' : fileContentsInB64}

That's also the format you have to use when uploading files to Object Storage via the REST interface if you want to be able to view them through the FIWARE Lab web GUI.

Actually, that's the only format I was able to use in order to get the REST interface working consistently for both text and binary files. You will notice that the "example python" from the enabler's documentation only deals with text files - that's why it manages to work without Base64 encoding and decoding. Therefore, the "example python" should not be treated as a complete reference ;)

Besides changing the putObject() payload format to json I also added Base64 encoding (and decoding in getObject()) of the actual file contents.

Since the json contains the mimeType information (and since the payload is a json), it's also not necessary to alter the swift request's Content-Type field in putObject().
